### PR TITLE
Feat : oauth2 로그인 구현 (google,naver)

### DIFF
--- a/src/main/java/com/grinder/controller/entity/SellerApplyController.java
+++ b/src/main/java/com/grinder/controller/entity/SellerApplyController.java
@@ -1,7 +1,7 @@
 package com.grinder.controller.entity;
 
 import com.grinder.domain.dto.SuccessResult;
-import com.grinder.security.CustomUserDetails;
+import com.grinder.security.dto.CustomUserDetails;
 import com.grinder.service.SellerApplyService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -12,7 +12,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
-import java.util.List;
+
 import static com.grinder.domain.dto.SellerApplyDTO.*;
 
 @RestController

--- a/src/main/java/com/grinder/controller/view/AccountPageController.java
+++ b/src/main/java/com/grinder/controller/view/AccountPageController.java
@@ -3,6 +3,7 @@ package com.grinder.controller.view;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 
 @Controller
@@ -15,7 +16,9 @@ public class AccountPageController {
     }
 
     @GetMapping("/page/signup")
-    public String viewSignupPage(){return "addMemberForm";}
+    public String viewSignupPage(@RequestParam(name = "email", required = false) String email){
+        return "addMemberForm";
+    }
 
     @GetMapping("/page/find/account")
     public String viewFindAccountPage(){return "findAccountForm";}

--- a/src/main/java/com/grinder/exception/UserRegistrationException.java
+++ b/src/main/java/com/grinder/exception/UserRegistrationException.java
@@ -1,0 +1,16 @@
+package com.grinder.exception;
+
+import lombok.Getter;
+import org.springframework.security.core.AuthenticationException;
+
+
+@Getter
+public class UserRegistrationException extends AuthenticationException {
+
+    private String email;
+
+    public UserRegistrationException(String message, String email) {
+        super(message);
+        this.email = email;
+    }
+}

--- a/src/main/java/com/grinder/security/dto/CustomOauth2Member.java
+++ b/src/main/java/com/grinder/security/dto/CustomOauth2Member.java
@@ -1,0 +1,42 @@
+package com.grinder.security.dto;
+
+import com.grinder.domain.entity.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+
+@RequiredArgsConstructor
+public class CustomOauth2Member implements OAuth2User {
+
+    private final Member member;
+
+    @Override
+    public Map<String,Object> getAttributes(){
+        return null;
+    }
+
+    @Override
+    public Collection<?extends GrantedAuthority> getAuthorities(){
+        Collection<GrantedAuthority> collection = new ArrayList<>();
+
+        collection.add(new GrantedAuthority() {
+            @Override
+            public String getAuthority() {
+                return member.getRole().getValue();
+            }
+        });
+        return collection;
+    }
+
+    @Override
+    public String getName(){
+        return member.getNickname();
+    }
+    public String getEmail(){
+        return member.getEmail();
+    }
+}

--- a/src/main/java/com/grinder/security/dto/CustomUserDetails.java
+++ b/src/main/java/com/grinder/security/dto/CustomUserDetails.java
@@ -1,4 +1,4 @@
-package com.grinder.security;
+package com.grinder.security.dto;
 
 import com.grinder.domain.entity.Member;
 import org.springframework.security.core.GrantedAuthority;

--- a/src/main/java/com/grinder/security/dto/GoogleResponse.java
+++ b/src/main/java/com/grinder/security/dto/GoogleResponse.java
@@ -1,0 +1,36 @@
+package com.grinder.security.dto;
+
+import java.util.Map;
+
+public class GoogleResponse implements OAuth2Response{
+    private final Map<String, Object> attribute;
+
+    public GoogleResponse(Map<String, Object> attribute) {
+
+        this.attribute = attribute;
+    }
+
+    @Override
+    public String getProvider() {
+
+        return "google";
+    }
+
+    @Override
+    public String getProviderId() {
+
+        return attribute.get("sub").toString();
+    }
+
+    @Override
+    public String getEmail() {
+
+        return attribute.get("email").toString();
+    }
+
+    @Override
+    public String getName() {
+
+        return attribute.get("name").toString();
+    }
+}

--- a/src/main/java/com/grinder/security/dto/NaverResponse.java
+++ b/src/main/java/com/grinder/security/dto/NaverResponse.java
@@ -1,0 +1,36 @@
+package com.grinder.security.dto;
+
+import java.util.Map;
+
+public class NaverResponse implements OAuth2Response{
+    private final Map<String, Object> attribute;
+
+    public NaverResponse(Map<String, Object> attribute) {
+
+        this.attribute = (Map<String, Object>) attribute.get("response");
+    }
+
+    @Override
+    public String getProvider() {
+
+        return "naver";
+    }
+
+    @Override
+    public String getProviderId() {
+
+        return attribute.get("id").toString();
+    }
+
+    @Override
+    public String getEmail() {
+
+        return attribute.get("email").toString();
+    }
+
+    @Override
+    public String getName() {
+
+        return attribute.get("name").toString();
+    }
+}

--- a/src/main/java/com/grinder/security/dto/OAuth2Response.java
+++ b/src/main/java/com/grinder/security/dto/OAuth2Response.java
@@ -1,0 +1,11 @@
+package com.grinder.security.dto;
+
+public interface OAuth2Response {
+
+    String getProvider();
+
+    String getProviderId();
+
+    String getEmail();
+    String getName();
+}

--- a/src/main/java/com/grinder/security/filter/APILogoutFilter.java
+++ b/src/main/java/com/grinder/security/filter/APILogoutFilter.java
@@ -13,6 +13,7 @@ import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.filter.GenericFilterBean;

--- a/src/main/java/com/grinder/security/filter/TokenCheckFilter.java
+++ b/src/main/java/com/grinder/security/filter/TokenCheckFilter.java
@@ -1,6 +1,6 @@
 package com.grinder.security.filter;
 
-import com.grinder.security.MemberDetailsService;
+import com.grinder.security.service.MemberDetailsService;
 import com.grinder.security.exception.AccessTokenException;
 import com.grinder.utils.JWTUtil;
 import io.jsonwebtoken.ExpiredJwtException;

--- a/src/main/java/com/grinder/security/handler/APILoginFailureHandler.java
+++ b/src/main/java/com/grinder/security/handler/APILoginFailureHandler.java
@@ -1,7 +1,7 @@
 package com.grinder.security.handler;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gson.Gson;
+import com.grinder.exception.UserRegistrationException;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -20,27 +20,33 @@ public class APILoginFailureHandler implements AuthenticationFailureHandler {
 
     @Override
     public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
-        Map<String, String> errorDetails = new HashMap<>();
-
-        if (exception instanceof BadCredentialsException) {
-            errorDetails.put("code", "로그인 실패");
-            errorDetails.put("message", "아이디 또는 비밀번호가 일치하지 않습니다.");
-        } else if (exception instanceof InternalAuthenticationServiceException) {
-            errorDetails.put("code", "계정 비활성화");
-            errorDetails.put("message", "계정이 비활성화되었습니다. 관리자에게 문의하세요.");
+        if (exception instanceof UserRegistrationException) {
+            String email = ((UserRegistrationException)exception).getEmail();
+            response.sendRedirect("/page/signup?email="+email);
         } else {
-            errorDetails.put("code", "인증 실패");
-            errorDetails.put("message", "인증 과정에서 오류가 발생했습니다.");
+
+            Map<String, String> errorDetails = new HashMap<>();
+
+            if (exception instanceof BadCredentialsException) {
+                errorDetails.put("code", "로그인 실패");
+                errorDetails.put("message", "아이디 또는 비밀번호가 일치하지 않습니다.");
+            } else if (exception instanceof InternalAuthenticationServiceException) {
+                errorDetails.put("code", "계정 비활성화");
+                errorDetails.put("message", "계정이 비활성화되었습니다. 관리자에게 문의하세요.");
+            } else {
+                errorDetails.put("code", "인증 실패");
+                errorDetails.put("message", "인증 과정에서 오류가 발생했습니다.");
+            }
+
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.setContentType("application/json");
+            response.setCharacterEncoding("UTF-8");
+
+            Gson gson = new Gson();
+
+            String jsonResponse = gson.toJson(errorDetails);
+
+            response.getWriter().println(jsonResponse);
         }
-
-        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-        response.setContentType("application/json");
-        response.setCharacterEncoding("UTF-8");
-
-        Gson gson = new Gson();
-
-        String jsonResponse = gson.toJson(errorDetails);
-
-        response.getWriter().println(jsonResponse);
     }
 }

--- a/src/main/java/com/grinder/security/handler/APILoginSuccessHandler.java
+++ b/src/main/java/com/grinder/security/handler/APILoginSuccessHandler.java
@@ -3,6 +3,8 @@ package com.grinder.security.handler;
 import com.google.gson.Gson;
 import com.grinder.domain.entity.RefreshEntity;
 import com.grinder.repository.RefreshRepository;
+import com.grinder.security.dto.CustomOauth2Member;
+import com.grinder.security.dto.CustomUserDetails;
 import com.grinder.utils.JWTUtil;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.Cookie;
@@ -34,13 +36,20 @@ public class APILoginSuccessHandler implements AuthenticationSuccessHandler {
                                         Authentication authentication) throws IOException, ServletException{
         log.info("Login Success Handler-----------------");
 
+
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
 
-        log.info(authentication.toString());
-        log.info(authentication.getName());
+        log.info(String.valueOf(authentication.getPrincipal().getClass()));
+        String email = null;
+        if(authentication.getPrincipal() instanceof CustomOauth2Member){
+            CustomOauth2Member customOauth2Member = (CustomOauth2Member) authentication.getPrincipal();
+            email = customOauth2Member.getEmail();
+        } else{
+            CustomUserDetails customUserDetails = (CustomUserDetails)authentication.getPrincipal();
+            email = customUserDetails.getUsername();
+        }
 
-
-        Map<String, Object> claim = Map.of("email", authentication.getName());
+        Map<String, Object> claim = Map.of("email", email);
         //Access Token 유효기간 1시간
         String accessToken = jwtUtil.generateToken(claim, 1);
         //Refresh Token 유효기간 1일
@@ -53,6 +62,7 @@ public class APILoginSuccessHandler implements AuthenticationSuccessHandler {
         response.addCookie(createCookie("access",accessToken));
         response.addCookie(createCookie("refresh",refreshToken));
         response.setStatus(HttpStatus.OK.value());
+        response.sendRedirect("/");
     }
     private Cookie createCookie(String key, String value) {
 

--- a/src/main/java/com/grinder/security/service/CustomOAuth2MemberService.java
+++ b/src/main/java/com/grinder/security/service/CustomOAuth2MemberService.java
@@ -1,0 +1,54 @@
+package com.grinder.security.service;
+
+import com.grinder.domain.entity.Member;
+import com.grinder.exception.UserRegistrationException;
+import com.grinder.repository.MemberRepository;
+import com.grinder.security.dto.CustomOauth2Member;
+import com.grinder.security.dto.GoogleResponse;
+import com.grinder.security.dto.NaverResponse;
+import com.grinder.security.dto.OAuth2Response;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import java.io.IOException;
+
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2MemberService extends DefaultOAuth2UserService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException{
+
+        OAuth2User oAuth2User =  super.loadUser(userRequest);
+
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        OAuth2Response oAuth2Response = null;
+        if(registrationId.equals("naver")){
+            oAuth2Response = new NaverResponse(oAuth2User.getAttributes());
+        } else if(registrationId.equals("google")){
+            oAuth2Response = new GoogleResponse(oAuth2User.getAttributes());
+        } else{
+            return null;
+        }
+        String email = oAuth2Response.getEmail();
+        if(memberRepository.existsByEmail(email)){
+            // DB에 유저 정보 있을 시
+            Member member = memberRepository.findByEmail(email).orElse(null);
+            return new CustomOauth2Member(member);
+        } else{
+            //DB에 유저 정보 없을 시 -> 빠져나와서 회원가입 유도 -> 이메일만 넣어주기 -> 보안상의 이유로 권장은 안함..
+            throw new UserRegistrationException("User not registered", email);
+
+        }
+    }
+
+}

--- a/src/main/java/com/grinder/security/service/MemberDetailsService.java
+++ b/src/main/java/com/grinder/security/service/MemberDetailsService.java
@@ -1,7 +1,8 @@
-package com.grinder.security;
+package com.grinder.security.service;
 
 import com.grinder.domain.entity.Member;
 import com.grinder.repository.MemberRepository;
+import com.grinder.security.dto.CustomUserDetails;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;

--- a/src/main/resources/static/js/addMemberForm.js
+++ b/src/main/resources/static/js/addMemberForm.js
@@ -16,6 +16,27 @@ let emailCheck = false;
 let emailVerifyCheck = false;
 let passwordCheck = false;
 let nicknameCheck = false;
+
+window.addEventListener('DOMContentLoaded', function() {
+    const urlParams = new URLSearchParams(window.location.search);
+    const email = urlParams.get('email');
+    if (email) {
+        emailInput.value = email;
+        emailVerifyCheck = true;
+        sendButton.disabled = true;
+        verifyButton.disabled = true;
+        codeInput.disabled = true;
+        sendButton.style.backgroundColor = "gray";
+        verifyButton.style.backgroundColor = "gray";
+        codeInput.placeholder = "인증이 완료되었습니다";
+        verifySpanElement.textContent = "(소셜 로그인)인증된 이메일입니다.";
+        verifySpanElement.style.color ='#00780C';
+        emailSpanElement.textContent = '사용 가능한 이메일입니다.';
+        emailSpanElement.style.color ='#00780C';
+        emailCheck = true;
+    }
+});
+
 // 이메일 중복확인
 emailInput.addEventListener('input', function() {
     const email = emailInput.value;

--- a/src/main/resources/static/js/loginPage.js
+++ b/src/main/resources/static/js/loginPage.js
@@ -1,4 +1,6 @@
- document.addEventListener('DOMContentLoaded', function() {
+const naverBtn = document.querySelector("#naver-btn");
+const googleBtn = document.querySelector("#google-btn");
+document.addEventListener('DOMContentLoaded', function() {
         const emailInput = document.querySelector('#emailInput');
         const passwordInput = document.querySelector('#pwInput');
         const loginButton = document.querySelector('.btn-login');
@@ -42,7 +44,7 @@
                     // 서버로부터 받은 응답 처리
                     console.log(data);
 
-                    // 성공적으로 로그인되었을 때 특정 URL로 이동
+                    // // 성공적으로 로그인되었을 때 특정 URL로 이동
                     window.location.href = '/'; // 이동할 URL로 수정
                 })
                 .catch(error => {
@@ -52,3 +54,12 @@
         });
     });
 
+naverBtn.addEventListener('click', () => {
+    // GET 요청 보내기
+    window.location.href = '/oauth2/authorization/naver';
+});
+
+googleBtn.addEventListener('click', () => {
+    // GET 요청 보내기
+    window.location.href = '/oauth2/authorization/google';
+});

--- a/src/main/resources/templates/loginForm.html
+++ b/src/main/resources/templates/loginForm.html
@@ -19,18 +19,18 @@
         </div>
         <button class="btn-login">로그인</button>
         <div class="a-wrap">
-            <a href="">회원가입</a>
+            <a href="/page/signup">회원가입</a>
             <a href="">비밀번호를 잊어버리셨나요?</a>
         </div>
         <hr>
         <span>다른 계정으로 로그인</span>
         <div class="social-box1">
             <img src="/img/icon/icon_google.png" alt="icon_google">
-            <button>구글 계정으로 로그인</button>
+            <button id="google-btn">구글 계정으로 로그인</button>
         </div>
         <div class="social-box2">
             <img src="/img/icon/icon_naver.png" alt="icon_naver">
-            <button>네이버 계정으로 로그인</button>
+            <button id="naver-btn">네이버 계정으로 로그인</button>
         </div>
     </article>
 </main>


### PR DESCRIPTION
### 🔍구현 내용

- 소셜로그인(oauth2) 구현
- 프론트에 적용완료

### 🙏요구 사항

- 소셜로그인 후 로그아웃 시 세션 남아있는 부분은 해결할 수 있는지 봐야될 것 같습니다.
- 구조가 소셜로그인 시도 -> 등록 안되어있는 유저면 회원가입 진행(이메일 적용됨) -> 추후 소셜로그인시 바로 로그인 가능하게 구현했습니다.

### 🎫티켓 번호

- [KAN-49]

[KAN-49]: https://alcuz137-1713936630736.atlassian.net/browse/KAN-49?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ